### PR TITLE
Deprecate app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+## :brazil: Aviso de depreciação
+
+Este app foi renomeado!
+
+Para saber mais sobre os motivos que levaram ao renomeio, você pode ler a discussão inteira [aqui](https://github.com/flathub/br.gov.fazenda.receita.irpf/issues/54).
+
+Na prática, para a maioria dos usuários, esta mudança não deve ser tão impactante, pois a migração para o novo pacote 2023 do app será automática.
+
+Em resumo, com essa mudança, a sua instalação do IRPF não será mais atualizada automaticamente todo ano.
+
+Por exemplo, para utilizar o IRPF 2024, você precisará instalar um pacote diferente do pacote IRPF 2023.
+
+Isso também significa que agora você pode manter múltiplas versões do IRPF instaladas ao mesmo tempo, sem causar conflitos, o que é útil caso você precise retificar declarações de anos passados.
+
+## :us: Deprecation warning
+
+This app has been renamed!
+
+To learn more about the reasons behind this renaming process, you can read the entire discussion [here](https://github.com/flathub/br.gov.fazenda.receita.irpf/issues/54) (in Portuguese).
+
+In practice, this change should not be that impactful for most users, because the migration to the new 2023 package will be automatic.
+
+In short, with this change, your IRPF install will no longer get automatic updates every new year.
+
+For example, to use IRPF 2024, you will have to install a different package from IRPF 2023.
+
+This also means you can now keep multiple versions of IRPF installed simultaneously, without causing conflicts, which is useful if you have to refile tax information from previous years.
+

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,4 @@
+{
+    "end-of-life": "App renomeado para: br.gov.fazenda.receita.irpf2023. Leia: https://github.com/flathub/br.gov.fazenda.receita.irpf/issues/54",
+    "end-of-life-rebase": "br.gov.fazenda.receita.irpf2023"
+}


### PR DESCRIPTION
The app has been renamed to: https://github.com/flathub/br.gov.fazenda.receita.irpf2023
Learn more about this change here (in Portuguese): https://github.com/flathub/br.gov.fazenda.receita.irpf/issues/54

NOTE: This PR will only be accepted once the Flathub page for the new app is live at: https://flathub.org/apps/br.gov.fazenda.receita.irpf2023

Closes #54